### PR TITLE
Add ruby 'pg' gem instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 - [pgbadger.md](/pgbadger.md)
 - [graphviz.md](/graphviz.md)
 - [bundler.md](/bundler.md)
+- [ruby_pg_gem.md](/ruby_pg_gem.md)
 - [ruby_on_rails.md](/ruby_on_rails.md)
 - [ruby.md](/ruby.md)
 - [postgresapp.md](/postgresapp.md)

--- a/ruby_pg_gem.md
+++ b/ruby_pg_gem.md
@@ -1,0 +1,29 @@
+# `pg` Ruby gem
+
+📁 [Table of Contents](README.md)
+
+## Description
+
+Pg is the Ruby interface to the PostgreSQL RDBMS. 
+
+### Steps
+
+This will be installed as a dependency of the Rails app, that works with PostgreSQL.
+
+### Extra help
+
+<https://github.com/ged/ruby-pg#how-to-install>
+
+These instructions are from that project:
+
+You may need to specify the path to the 'pg_config' program installed with Postgres:
+
+```sh
+gem install pg -- --with-pg-config=<path to pg_config>
+```
+
+If you're installing via Bundler, you can provide compile hints like so:
+
+```
+bundle config build.pg --with-pg-config=<path to pg_config>
+```


### PR DESCRIPTION
This gem is used to connect with PostgreSQL

The gem provides some extra help on instructions for the native portions
for users that run into installation errors.
